### PR TITLE
perf: inject CSS once into <head>, add font preloads, add render cache

### DIFF
--- a/Math.md
+++ b/Math.md
@@ -76,34 +76,111 @@ syntax.define {
 ```space-lua
 local location = "Library/mrmugame/Silverbullet-Math"
 
+-- Inject the KaTeX stylesheet once into the document <head>.
+-- Previously this was done by embedding a <link> tag inside every widget's
+-- HTML string. That caused a per-render network round-trip (cache validation)
+-- every time CodeMirror's virtual viewport destroyed and recreated a widget
+-- on scroll, producing a visible flash of unstyled math — more noticeable on
+-- slow connections. Injecting it once here means the browser loads the CSS
+-- exactly once and it persists for the lifetime of the page.
+-- The data-katex-css sentinel attribute prevents double-injection if this
+-- space-lua block is evaluated more than once (e.g. after a reload).
+if not js.window.document.querySelector("link[data-katex-css]") then
+  local link = js.window.document.createElement("link")
+  link.rel = "stylesheet"
+  link.href = string.format(".fs/%s/katex.min.css", location)
+  link.setAttribute("data-katex-css", "true")
+  js.window.document.head.appendChild(link)
+end
+
+-- Preload the KaTeX fonts that are needed for typical math rendering.
+-- Without preloading, the browser only discovers fonts after parsing the
+-- stylesheet, creating a waterfall: CSS fetch → font discovery → font fetch.
+-- Preload hints let the browser fetch fonts in parallel with the CSS,
+-- eliminating that waterfall entirely.
+-- Not all 22 bundled fonts are preloaded — only the subset used by ordinary
+-- mathematical text. Exotic fonts (Fraktur, Caligraphic, Typewriter, Script)
+-- are left to lazy-load on demand since most pages never use them.
+local preloadFonts = {
+  "KaTeX_Main-Regular",
+  "KaTeX_Main-Bold",
+  "KaTeX_Main-Italic",
+  "KaTeX_Math-Italic",
+  "KaTeX_Math-BoldItalic",
+  "KaTeX_AMS-Regular",
+  "KaTeX_Size1-Regular",
+  "KaTeX_Size2-Regular",
+  "KaTeX_Size3-Regular",
+  "KaTeX_Size4-Regular",
+  "KaTeX_SansSerif-Regular",
+}
+for _, fontName in ipairs(preloadFonts) do
+  local fontHref = string.format(".fs/%s/fonts/%s.woff2", location, fontName)
+  -- Guard with a sentinel attribute to avoid duplicate <link> elements on
+  -- re-evaluation, same pattern as the stylesheet injection above.
+  if not js.window.document.querySelector(
+    string.format("link[data-katex-font='%s']", fontName)
+  ) then
+    local preload = js.window.document.createElement("link")
+    preload.rel = "preload"
+    preload.href = fontHref
+    preload.setAttribute("as", "font")
+    preload.setAttribute("type", "font/woff2")
+    preload.setAttribute("crossorigin", "anonymous")
+    preload.setAttribute("data-katex-font", fontName)
+    js.window.document.head.appendChild(preload)
+  end
+end
+
 latex = {
-  header = string.format("<link rel=\"stylesheet\" href=\".fs/%s/katex.min.css\">", location),
-  katex = js.import(string.format("%s.fs/%s/katex.mjs", system.getURLPrefix(),  location))
+  -- js.import resolves the ES module once at space-lua initialisation time.
+  -- The resolved module object is stored here and reused for every render call,
+  -- so there is no repeated module fetch or promise re-await on scroll.
+  katex = js.import(string.format("%s.fs/%s/katex.mjs", system.getURLPrefix(), location)),
+
+  -- In-memory render cache. renderToString is a pure function: the same
+  -- (expression, displayMode) pair always produces the same HTML string.
+  -- Caching the result means each unique expression is rendered by KaTeX
+  -- exactly once per session. Subsequent calls — including every scroll-in
+  -- re-render by CodeMirror's virtual viewport — return instantly from memory
+  -- without invoking KaTeX at all.
+  cache = {}
 }
 
-function latex.inline(expression)
+-- Internal helper: render expression via KaTeX, returning cached HTML if
+-- available, or calling renderToString and storing the result otherwise.
+local function renderCached(expression, displayMode)
+  local key = (displayMode and "block:" or "inline:") .. expression
+  -- Use ~= nil rather than a truthiness check: KaTeX always returns a non-empty
+  -- string, but a truthiness check would incorrectly re-render any cached value
+  -- that happens to be falsy (empty string, false, 0 in Lua).
+  if latex.cache[key] ~= nil then
+    return latex.cache[key]
+  end
   local html = latex.katex.renderToString(expression, {
     trust = true,
     throwOnError = false,
-    displayMode = false
+    displayMode = displayMode
   })
+  latex.cache[key] = html
+  return html
+end
 
+function latex.inline(expression)
+  -- Render inline math (displayMode = false keeps the formula on the same
+  -- baseline as surrounding text).
   return widget.new {
     display = "inline",
-    html = "<span>" .. latex.header .. html .. "</span>"
+    html = "<span>" .. renderCached(expression, false) .. "</span>"
   }
 end
 
 function latex.block(expression)
-  local html = latex.katex.renderToString(expression, {
-    trust = true,
-    throwOnError = false,
-    displayMode = true
-  })
-
+  -- Render display math (displayMode = true centres the formula on its own
+  -- line with larger delimiters).
   return widget.new {
     display = "block",
-    html = "<span>" .. latex.header .. html .. "</span>"
+    html = "<span>" .. renderCached(expression, true) .. "</span>"
   }
 end
 ```


### PR DESCRIPTION
# perf: inject CSS once into `<head>`, add font preloads, add render cache

This is AI-generated code, please feel free to reject this PR, I'm just using the PR to suggest a possible solution. This PR addresses issue #8 .

## Problem

The original implementation embedded a `<link rel="stylesheet">` tag directly inside the HTML string of every widget returned by `latex.inline` and `latex.block`. CodeMirror's virtual viewport destroys and recreates widget DOM nodes as the user scrolls, so each scroll event triggered a fresh CSS network request (even if cached, the browser still performs a conditional GET for revalidation). On slow connections this produced a visible flash of unstyled math on every scroll.

## Changes

### 1. CSS injected once into `<head>`

The stylesheet is now inserted imperatively into `document.head` at space-lua initialisation time, outside any render function:

```lua
if not js.window.document.querySelector("link[data-katex-css]") then
  local link = js.window.document.createElement("link")
  ...
  link.setAttribute("data-katex-css", "true")
  js.window.document.head.appendChild(link)
end
```

The `data-katex-css` sentinel attribute is the idempotency guard: because space-lua blocks can be re-evaluated (e.g. on page reload), the `querySelector` check prevents a second `<link>` from being injected. **If you ever rename this attribute, update the guard to match, or double-injection will occur.**

### 2. Font preloads

Without preload hints the browser discovers fonts only after it has fetched and parsed `katex.min.css` — a serial waterfall. The new code adds `<link rel="preload" as="font">` elements for the 11 fonts needed by ordinary mathematical text, letting the browser fetch fonts in parallel with the CSS.

The 11 fonts in `preloadFonts` are a deliberate subset. The remaining fonts bundled in the `files` list (Fraktur, Caligraphic, Typewriter, Script) are intentionally left to lazy-load because most pages never use them. **If you add a new font to the `files` frontmatter, do not add it to `preloadFonts` unless you have confirmed it is needed on nearly every page.** Each preload hint is an unconditional network request — preloading rarely-used fonts would regress performance on pages that do not use them.

The same sentinel pattern (`data-katex-font="<name>"`) guards font preloads against double-injection on re-evaluation.

### 3. In-memory render cache

`renderToString` is a pure function: identical `(expression, displayMode)` inputs always produce the same HTML string. The new `latex.cache` table memoises results so KaTeX is called at most once per unique expression per session. Subsequent calls — including every scroll-in re-render by CodeMirror — return instantly from the table.

The cache key is `"block:<expr>"` or `"inline:<expr>"` to prevent a block and an inline render of the same expression from colliding.

**The cache hit check uses `~= nil`, not a truthiness check.** This is load-bearing: Lua treats the empty string and `false` as falsy, so a plain `if latex.cache[key] then` would incorrectly re-render any cached value that happened to be one of those. KaTeX never returns an empty string for valid input, but the `~= nil` form is correct by construction and should be preserved if the cache logic is ever touched.

The `latex.header` field has been removed from the `latex` table entirely, since CSS is no longer embedded in widget HTML. **Do not re-add `latex.header` or any inline `<link>` tag inside widget HTML strings** — that would reintroduce the scroll-flash bug.


## What was not changed

- The `Syntax` block is unchanged.
- The `space-style` block is unchanged.
- The `files` frontmatter list is unchanged.
- `latex.inline` and `latex.block` remain the public API; their signatures and return types are identical.
- `trust = true` and `throwOnError = false` are preserved on all `renderToString` calls.
